### PR TITLE
anonymize ip in google analytics

### DIFF
--- a/brand/default.xml
+++ b/brand/default.xml
@@ -36,6 +36,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-10013579-13', 'auto');
+      ga('set', 'anonymizeIp, 'auto');
       ga('send', 'pageview');
       </script>
 


### PR DESCRIPTION
Following instructions [here](https://www.optimizesmart.com/how-to-turn-on-ip-anonymization-in-google-analytics-and-google-tag-manager/) to anonymize the IP addresses of users in the Google Analytics script. I'm not too familiar with this code base, so I want to make sure I'm doing this in the right place.

Fixes #404 